### PR TITLE
Sound-rework

### DIFF
--- a/BranchInfo.md
+++ b/BranchInfo.md
@@ -1,9 +1,0 @@
-Remove way is fail
-each grenade type share controller.AnimationEventsEmitter._animationEventsStateBehaviours
-
-```c#
-AnimationEventSystem.AnimationEventsStateBehaviour fuseEvent1 = controller.AnimationEventsEmitter._animationEventsStateBehaviours
-    .OfType<AnimationEventSystem.AnimationEventsStateBehaviour>()
-    .FirstOrDefault(x => x.AnimationEvents.FirstOrDefault(y => y._functionName == "SoundAtPoint" && y.Parameter.StringParam == "SndFuse") != null);
-fuseEvent1.AnimationEvents.Remove(fuseEvent);
-```

--- a/BranchInfo.md
+++ b/BranchInfo.md
@@ -1,0 +1,9 @@
+Remove way is fail
+each grenade type share controller.AnimationEventsEmitter._animationEventsStateBehaviours
+
+```c#
+AnimationEventSystem.AnimationEventsStateBehaviour fuseEvent1 = controller.AnimationEventsEmitter._animationEventsStateBehaviours
+    .OfType<AnimationEventSystem.AnimationEventsStateBehaviour>()
+    .FirstOrDefault(x => x.AnimationEvents.FirstOrDefault(y => y._functionName == "SoundAtPoint" && y.Parameter.StringParam == "SndFuse") != null);
+fuseEvent1.AnimationEvents.Remove(fuseEvent);
+```

--- a/Config/ConfigManager.cs
+++ b/Config/ConfigManager.cs
@@ -5,6 +5,7 @@ internal static class ConfigManager
 {
     public static ConfigEntry<bool> EnableCookingNotification;
     public static ConfigEntry<bool> ShowDefaultFuseTimeInInventoryUI;
+    public static ConfigEntry<bool> UseAlternativePinSound;
     #region RealisticFuseTime
     public static ConfigEntry<bool> RealisticFuseTimeEnable;
     public static ConfigEntry<float> FuseTimeSpreadFactor;
@@ -39,8 +40,16 @@ internal static class ConfigManager
                 "If enabled, shows the default fuse time in inventory UI instead of randomized value.",
                 null,
                 new ConfigurationManagerAttributes {}));
+        UseAlternativePinSound = configFile.Bind(
+            "0. Cooking Grenades",
+            "Use Alternative Pin Sound",
+            true,
+            new ConfigDescription(
+                "If enabled, plays an alternative pin sound (TripwirePin) for certain grenades instead of the fuse sound.\n" +
+                "Affected grenades: M67, V40, M18, M7290, RDG-2B",
+                null,
+                new ConfigurationManagerAttributes { Order = -1 }));
 
-                
         #region RealisticFuseTime
 
         RealisticFuseTimeEnable = configFile.Bind(

--- a/GrenadeCookingTimer.cs
+++ b/GrenadeCookingTimer.cs
@@ -15,21 +15,21 @@ public class GrenadeCookingTimer
 {
     private float _cookingStartTime = 0f;
     public float CookingStartTime => _cookingStartTime;
-    public bool IsCooking => _cookingStartTime > 0f && CookingItem != null;
-    public ThrowWeapItemClass CookingItem { get; private set; }
+    public bool IsCooking => _cookingStartTime > 0f && Controller != null;
+    public Player.GrenadeHandsController Controller { get; private set; }
     public Coroutine existingCoroutine =null;
     public GrenadeCookingTimer()
     {
-        CookingItem = null;
+        Controller = null;
     }
-    public GrenadeCookingTimer(ThrowWeapItemClass item)
+    public GrenadeCookingTimer(Player.GrenadeHandsController controller)
     {
-        CookingItem = item;
+        Controller = controller;
     }
 
-    public void SetCookingItem(ThrowWeapItemClass item)
+    public void SetCookingItem(Player.GrenadeHandsController controller)
     {
-        CookingItem = item;
+        Controller = controller;
         _cookingStartTime = 0f;
     }
     public void StartCooking(Player.GrenadeHandsController controller)
@@ -59,7 +59,7 @@ public class GrenadeCookingTimer
 
     public void Reset(Player.GrenadeHandsController oldController)
     {
-        CookingItem = null;
+        Controller = null;
         _cookingStartTime = 0f;
         oldController.StopCoroutine(existingCoroutine);
         oldController = null;

--- a/Patches/BaseSoundPlayerOnSoundAtPointPatch.cs
+++ b/Patches/BaseSoundPlayerOnSoundAtPointPatch.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Reflection;
+using SPT.Reflection.Patching;
+using EFT.UI.Map;
+using HarmonyLib;
+using EFT.UI.WeaponModding;
+using UnityEngine;
+using System.Collections.Generic;
+using CookingGrenades.Config;
+using System.Threading.Tasks;
+using EFT;
+using SPT.Custom.Utils;
+using EFT.InputSystem;
+using AnimationEventSystem;
+
+namespace CookingGrenades.Patches;
+
+public class BaseSoundPlayerOnSoundAtPointPatch : ModulePatch
+{
+    protected override MethodBase GetTargetMethod()
+    {
+        // 60sec and 600call not good performance
+        return AccessTools.Method(typeof(BaseSoundPlayer), nameof(BaseSoundPlayer.OnSoundAtPoint));
+    }
+
+    public static BaseSoundPlayer HaveToNotRunFuseSound = null;
+    [PatchPrefix]
+    public static bool PatchPrefix(BaseSoundPlayer __instance, string StringParam)
+    {
+        if (HaveToNotRunFuseSound == __instance && 
+            StringParam == "SndFuse")
+        {
+            HaveToNotRunFuseSound = null;
+            return false; // skip original
+        }
+        return true; // run original
+    }
+}
+
+
+

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -26,9 +26,10 @@ namespace CookingGrenades
             Utils.FuseTimeTester.Init();
 
             new GrenadeInitPatch().Enable();
-            new GrenadeHandsControllermethod_2Patch().Enable();
             new PlayerGrenadeHandsControllerHandleFireInputPatch().Enable();
             new PlayerGrenadeHandsControllerHandleAltFireInputPatch().Enable();
+            new GrenadeHandsControllermethod_2Patch().Enable();
+            new BaseSoundPlayerOnSoundAtPointPatch().Enable();
             new EftGamePlayerOwnerTranslateCommandPatch().Enable();
             new ThrowWeapItemClassGetExplDelayPatch().Enable();
             if (!ConfigManager.UserWarningConfirmed.Value)

--- a/Utils/GrenadeCookingHelper.cs
+++ b/Utils/GrenadeCookingHelper.cs
@@ -8,39 +8,109 @@ public static class GrenadeCookingHelper
 {
     public static void StartCookingWithLeverSound(Player.GrenadeHandsController controller)
     {
-        var animator = controller.FirearmsAnimator.Animator;
         var cookingTimer = CookingGrenades.GrenadeCookingManager.GetCookingTimer();
 
         // Set the item to cook
-        cookingTimer.SetCookingItem(controller.Item);
-        // Find the lever sound event
-        AnimationEventSystem.AnimationEvent leverEvent = controller.AnimationEventsEmitter._animationEventsStateBehaviours
-            // Only consider objects that are of type AnimationEventsStateBehaviour
-            .OfType<AnimationEventSystem.AnimationEventsStateBehaviour>()
-            // Each AnimationEventsStateBehaviour contains a list of AnimationEvents
-            // SelectMany flattens all those lists into a single sequence for easy searching
-            .SelectMany(x => x.AnimationEvents)
-            .FirstOrDefault(evt => evt._functionName == "Sound" && evt.Parameter.StringParam == "Lever");
+        cookingTimer.SetCookingItem(controller);
 
-        if (leverEvent != null)
-        {
-            // Get current animator state and trigger the lever sound
-            var currentState = animator.GetCurrentAnimatorStateInfo(1);
-            controller.AnimationEventsEmitter.method_2(leverEvent.FunctionName, leverEvent.FunctionNameHash, leverEvent.Parameter, currentState.shortNameHash);
-
-            // // Alternative approach (for reference): Use BaseSoundPlayer to play lever sound
-            // var baseSoundPlayer = controller.ControllerGameObject.GetComponent<BaseSoundPlayer>();
-            // baseSoundPlayer.SoundEventHandler("Lever");
-        }
-        else
-        {
-            Plugin.log.LogError("Can't Find Sound Lever Event");
-        }
+        PlaySound(controller);
 
         if (ConfigManager.EnableCookingNotification.Value)
         {
             NotificationManagerClass.DisplayMessageNotification("Cooking Started");
         }
-        cookingTimer.StartCooking(controller);    
+        cookingTimer.StartCooking(controller);
+    }
+
+    private static void PlaySound(Player.GrenadeHandsController controller)
+    {
+        var animator = controller.FirearmsAnimator.Animator;
+        AnimationEventSystem.AnimationEvent fuseEvent = controller.AnimationEventsEmitter._animationEventsStateBehaviours
+            .OfType<AnimationEventSystem.AnimationEventsStateBehaviour>()
+            .SelectMany(x => x.AnimationEvents)
+            .FirstOrDefault(evt => evt._functionName == "SoundAtPoint" && evt.Parameter.StringParam == "SndFuse");
+
+        // If there's a fuse sound event, play it first.
+        if (fuseEvent != null)
+        {
+            var currentState = animator.GetCurrentAnimatorStateInfo(1);
+            controller.AnimationEventsEmitter.method_3(fuseEvent, animator, currentState, fuseEvent.Time);
+        }
+        else // Otherwise, play the ping sound. Similar one is "TripwirePin"
+        {
+            var baseSoundPlayer = controller.ControllerGameObject.GetComponent<BaseSoundPlayer>();
+            baseSoundPlayer.SoundEventHandler("TripwirePin");
+        }
+        // mark to disable fuze sound event after throw one time
+        Patches.BaseSoundPlayerOnSoundAtPointPatch.HaveToNotRunFuseSound = controller.ControllerGameObject.GetComponent<BaseSoundPlayer>();
     }
 }
+
+
+
+
+/*      
+
+-		[0]	{BaseSoundPlayer.SoundElement}	BaseSoundPlayer.SoundElement
+		EventName	"SndDraw"	string
++		SoundClips	{UnityEngine.AudioClip[0x00000001]}	UnityEngine.AudioClip[]
+-		[1]	{BaseSoundPlayer.SoundElement}	BaseSoundPlayer.SoundElement
+		EventName	"SndHolster"	string
++		SoundClips	{UnityEngine.AudioClip[0x00000001]}	UnityEngine.AudioClip[]
+-		[2]	{BaseSoundPlayer.SoundElement}	BaseSoundPlayer.SoundElement
+		EventName	"SndSafety"	string
++		SoundClips	{UnityEngine.AudioClip[0x00000001]}	UnityEngine.AudioClip[]
+-		[3]	{BaseSoundPlayer.SoundElement}	BaseSoundPlayer.SoundElement
+		EventName	"SndThrow"	string
++		SoundClips	{UnityEngine.AudioClip[0x00000001]}	UnityEngine.AudioClip[]
+-		[4]	{BaseSoundPlayer.SoundElement}	BaseSoundPlayer.SoundElement
+		EventName	"SndPin"	string
++		SoundClips	{UnityEngine.AudioClip[0x00000001]}	UnityEngine.AudioClip[]
+-		[5]	{BaseSoundPlayer.SoundElement}	BaseSoundPlayer.SoundElement
+		EventName	"SndLever"	string
++		SoundClips	{UnityEngine.AudioClip[0x00000001]}	UnityEngine.AudioClip[]
+-		[6]	{BaseSoundPlayer.SoundElement}	BaseSoundPlayer.SoundElement
+		EventName	"SndDropBackpack"	string
++		SoundClips	{UnityEngine.AudioClip[0x00000003]}	UnityEngine.AudioClip[]
+-		[7]	{BaseSoundPlayer.SoundElement}	BaseSoundPlayer.SoundElement
+		EventName	"SndFuse"	string
++		SoundClips	{UnityEngine.AudioClip[0x00000003]}	UnityEngine.AudioClip[]
+-		[8]	{BaseSoundPlayer.SoundElement}	BaseSoundPlayer.SoundElement
+		EventName	"SndDefuseEnd"	string
++		SoundClips	{UnityEngine.AudioClip[0x00000001]}	UnityEngine.AudioClip[]
+-		[9]	{BaseSoundPlayer.SoundElement}	BaseSoundPlayer.SoundElement
+		EventName	"SndDefuseLoop"	string
++		SoundClips	{UnityEngine.AudioClip[0x00000001]}	UnityEngine.AudioClip[]
+-		[10]	{BaseSoundPlayer.SoundElement}	BaseSoundPlayer.SoundElement
+		EventName	"SndTripwirePin"	string
++		SoundClips	{UnityEngine.AudioClip[0x00000001]}	UnityEngine.AudioClip[]
+-		[11]	{BaseSoundPlayer.SoundElement}	BaseSoundPlayer.SoundElement
+		EventName	"SndTripwirePlanting"	string
++		SoundClips	{UnityEngine.AudioClip[0x00000001]}	UnityEngine.AudioClip[]
+-		[12]	{BaseSoundPlayer.SoundElement}	BaseSoundPlayer.SoundElement
+		EventName	"SndTripwirePlantingConcrete"	string
++		SoundClips	{UnityEngine.AudioClip[0x00000001]}	UnityEngine.AudioClip[]
+-		[13]	{BaseSoundPlayer.SoundElement}	BaseSoundPlayer.SoundElement
+		EventName	"SndTripwirePlantingSoil"	string
++		SoundClips	{UnityEngine.AudioClip[0x00000001]}	UnityEngine.AudioClip[]
+-		[14]	{BaseSoundPlayer.SoundElement}	BaseSoundPlayer.SoundElement
+		EventName	"SndTripwirePlantingWire"	string
++		SoundClips	{UnityEngine.AudioClip[0x00000001]}	UnityEngine.AudioClip[]
+-		[15]	{BaseSoundPlayer.SoundElement}	BaseSoundPlayer.SoundElement
+		EventName	"SndTripwireUnplanting"	string
++		SoundClips	{UnityEngine.AudioClip[0x00000001]}	UnityEngine.AudioClip[]
+-		[16]	{BaseSoundPlayer.SoundElement}	BaseSoundPlayer.SoundElement
+		EventName	"SndTripwireUnplantingWire"	string
++		SoundClips	{UnityEngine.AudioClip[0x00000001]}	UnityEngine.AudioClip[]
+-		[17]	{BaseSoundPlayer.SoundElement}	BaseSoundPlayer.SoundElement
+		EventName	"SndHands1"	string
++		SoundClips	{UnityEngine.AudioClip[0x00000001]}	UnityEngine.AudioClip[]
+-		[18]	{BaseSoundPlayer.SoundElement}	BaseSoundPlayer.SoundElement
+		EventName	"SndHands2"	string
++		SoundClips	{UnityEngine.AudioClip[0x00000001]}	UnityEngine.AudioClip[]
+-		[19]	{BaseSoundPlayer.SoundElement}	BaseSoundPlayer.SoundElement
+		EventName	"SndHands3"	string
++		SoundClips	{UnityEngine.AudioClip[0x00000001]}	UnityEngine.AudioClip[]
+
+
+*/

--- a/Utils/GrenadeCookingHelper.cs
+++ b/Utils/GrenadeCookingHelper.cs
@@ -28,8 +28,15 @@ public static class GrenadeCookingHelper
         var animator = controller.FirearmsAnimator.Animator;
         var baseSoundPlayer = controller.ControllerGameObject.GetComponent<BaseSoundPlayer>();
 
+        AnimationEventSystem.AnimationEvent fuseSoundEvent = controller.AnimationEventsEmitter._animationEventsStateBehaviours
+            .OfType<AnimationEventSystem.AnimationEventsStateBehaviour>()
+            .SelectMany(x => x.AnimationEvents)
+            .FirstOrDefault(evt => evt._functionName == "SoundAtPoint" && evt.Parameter.StringParam == "SndFuse");
+
+        bool shouldPlayAlternativeSound = fuseSoundEvent == null || 
+            (ConfigManager.UseAlternativePinSound.Value && ShouldSkipFuseSound(controller.Item.StringTemplateId));
         // check fuse sound and play the ping sound. Similar one is "TripwirePin"
-        if (ConfigManager.UseAlternativePinSound.Value && ShouldSkipFuseSound(controller.Item.StringTemplateId))
+        if (shouldPlayAlternativeSound)
         {                       
             // there is no TripwirePin Event in current _animationEventsStateBehaviours so have to play on baseSoundPlayer          
             baseSoundPlayer.SoundEventHandler("TripwirePin");
@@ -37,11 +44,6 @@ public static class GrenadeCookingHelper
         // Otherwise, play fuze sound
         else 
         {
-            AnimationEventSystem.AnimationEvent fuseSoundEvent = controller.AnimationEventsEmitter._animationEventsStateBehaviours
-                .OfType<AnimationEventSystem.AnimationEventsStateBehaviour>()
-                .SelectMany(x => x.AnimationEvents)
-                .FirstOrDefault(evt => evt._functionName == "SoundAtPoint" && evt.Parameter.StringParam == "SndFuse");
-
             var currentState = animator.GetCurrentAnimatorStateInfo(1);
             controller.AnimationEventsEmitter.method_3(fuseSoundEvent, animator, currentState, fuseSoundEvent.Time);
         }

--- a/Utils/GrenadeCookingHelper.cs
+++ b/Utils/GrenadeCookingHelper.cs
@@ -25,6 +25,8 @@ public static class GrenadeCookingHelper
     private static void PlaySound(Player.GrenadeHandsController controller)
     {
         var animator = controller.FirearmsAnimator.Animator;
+        var baseSoundPlayer = controller.ControllerGameObject.GetComponent<BaseSoundPlayer>();
+
         AnimationEventSystem.AnimationEvent fuseEvent = controller.AnimationEventsEmitter._animationEventsStateBehaviours
             .OfType<AnimationEventSystem.AnimationEventsStateBehaviour>()
             .SelectMany(x => x.AnimationEvents)
@@ -37,12 +39,11 @@ public static class GrenadeCookingHelper
             controller.AnimationEventsEmitter.method_3(fuseEvent, animator, currentState, fuseEvent.Time);
         }
         else // Otherwise, play the ping sound. Similar one is "TripwirePin"
-        {
-            var baseSoundPlayer = controller.ControllerGameObject.GetComponent<BaseSoundPlayer>();
+        {            
             baseSoundPlayer.SoundEventHandler("TripwirePin");
         }
         // mark to disable fuze sound event after throw one time
-        Patches.BaseSoundPlayerOnSoundAtPointPatch.HaveToNotRunFuseSound = controller.ControllerGameObject.GetComponent<BaseSoundPlayer>();
+        Patches.BaseSoundPlayerOnSoundAtPointPatch.HaveToNotRunFuseSound = baseSoundPlayer;
     }
 }
 

--- a/Utils/GrenadeCookingHelper.cs
+++ b/Utils/GrenadeCookingHelper.cs
@@ -29,7 +29,7 @@ public static class GrenadeCookingHelper
         var baseSoundPlayer = controller.ControllerGameObject.GetComponent<BaseSoundPlayer>();
 
         // check fuse sound and play the ping sound. Similar one is "TripwirePin"
-        if (ShouldSkipFuseSound(controller.Item.StringTemplateId))
+        if (ConfigManager.UseAlternativePinSound.Value && ShouldSkipFuseSound(controller.Item.StringTemplateId))
         {                       
             // there is no TripwirePin Event in current _animationEventsStateBehaviours so have to play on baseSoundPlayer          
             baseSoundPlayer.SoundEventHandler("TripwirePin");


### PR DESCRIPTION
🧩 Attempted to Remove SndFuse from AnimationEvents — But Failed
I initially tried to remove the "SndFuse" AnimationEvent from the shared list in
controller.AnimationEventsEmitter._animationEventsStateBehaviours like this:

```csharp
AnimationEventSystem.AnimationEventsStateBehaviour fuseEvent1 = controller.AnimationEventsEmitter._animationEventsStateBehaviours
    .OfType<AnimationEventSystem.AnimationEventsStateBehaviour>()
    .FirstOrDefault(x => x.AnimationEvents.FirstOrDefault(y => y._functionName == "SoundAtPoint" && y.Parameter.StringParam == "SndFuse") != null);
fuseEvent1.AnimationEvents.Remove(fuseEvent);
```

fuseEvent1.AnimationEvents.Remove(fuseEvent);
However, this failed because all grenade types share the same _animationEventsStateBehaviours instance.
Modifying it directly risks affecting other grenades unintentionally.


🔄 Switched from ReceiveEvent to OnSoundAtPoint for Performance Reasons
I also tried filtering out "SndFuse" from AnimationEventsEmitter.ReceiveEvent, but this method was called too frequently —
for example, over 600 times per minute on the Factory map.

To improve performance and ensure cleaner separation of concerns,
I moved the "SndFuse" filtering logic to BaseSoundPlayer.OnSoundAtPoint,
which is only called when the actual sound is about to play.